### PR TITLE
Support for multi-domain servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 * `security.shiro.cas.singleSignOut.disabled` (OPTIONAL): Boolean value controlling whether to disable Single Sign Out.  By default, this is `false`, resulting in Single Sign Out support being enabled (matching the default for CAS).  Note that this configuration value is used at build-time to modify the `web.xml`, and externalized configuration will not be taken into account during that phase.
 * `security.shiro.cas.singleSignOut.artifactParameterName` (OPTIONAL): The parameter used to detect sessions in preparation for Single Sign Out support.  By default, this is `ticket` (matching the default for CAS).
 * `security.shiro.cas.singleSignOut.logoutParameterName` (OPTIONAL): The parameter used to detect logout requests.  By default, this is `logoutRequest` (matching the default for CAS).
-* `security.shiro.cas.dynamicServerName` (OPTIONAL): The parameter used to denote a multi-domain server. Parameters `security.shiro.cas.serviceUri` and `security.shiro.cas.failureUri` are required if `true`. By default, this is `false`.
-* `security.shiro.cas.serviceUri` (OPTIONAL): REQUIRED if `security.shiro.cas.dynamicServerName` is `true`. This URI is appended to the server's base-URL when constructing `security.shiro.cas.serviceUrl`. This should be the path relative to the server at which end-users can reach `/shiro-cas` within the current application.
-* `security.shiro.cas.failureUri` (OPTIONAL): This URI is appended to the server's base-URL when constructing `security.shiro.cas.failureUrl`, the URL that users are redirected to if ticket validation fails.
+* `security.shiro.cas.servicePath` (OPTIONAL): This path is appended to the server's base-URL when constructing `security.shiro.cas.serviceUrl`. This should be the path relative to the server at which end-users can reach `/shiro-cas` within the current application.
+* `security.shiro.cas.failurePath` (OPTIONAL): This path is appended to the server's base-URL when constructing `security.shiro.cas.failureUrl`, the URL that users are redirected to if ticket validation fails.
 
 ## Example configuration
 
@@ -51,10 +50,9 @@ Assuming that:
 A valid configuration would be:
 
 ```groovy
-security.shiro.cas.dynamicServerName=true
-security.shiro.cas.serviceUri='/my-app/shiro-cas'
+security.shiro.cas.servicePath='/my-app/shiro-cas'
 security.shiro.cas.serverUrl='https://sso.example.com/cas'
-security.shiro.cas.serviceUrl='https://default.example.com' + security.shiro.cas.serviceUri //default serviceUrl
+security.shiro.cas.serviceUrl='https://default.example.com' + security.shiro.cas.servicePath //default serviceUrl
 ```
 
 # Accessing URLs

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 * `security.shiro.cas.singleSignOut.disabled` (OPTIONAL): Boolean value controlling whether to disable Single Sign Out.  By default, this is `false`, resulting in Single Sign Out support being enabled (matching the default for CAS).  Note that this configuration value is used at build-time to modify the `web.xml`, and externalized configuration will not be taken into account during that phase.
 * `security.shiro.cas.singleSignOut.artifactParameterName` (OPTIONAL): The parameter used to detect sessions in preparation for Single Sign Out support.  By default, this is `ticket` (matching the default for CAS).
 * `security.shiro.cas.singleSignOut.logoutParameterName` (OPTIONAL): The parameter used to detect logout requests.  By default, this is `logoutRequest` (matching the default for CAS).
-* `security.shiro.cas.servicePath` (OPTIONAL): This path is appended to the server's base-URL when constructing `security.shiro.cas.serviceUrl`. This should be the path relative to the server at which end-users can reach `/shiro-cas` within the current application.
-* `security.shiro.cas.failurePath` (OPTIONAL): This path is appended to the server's base-URL when constructing `security.shiro.cas.failureUrl`, the URL that users are redirected to if ticket validation fails.
+* `security.shiro.cas.servicePath` (OPTIONAL): Required for a multi-domain configuration. This path is appended to the server's base-URL when constructing `security.shiro.cas.serviceUrl`. This should be the path relative to the server at which end-users can reach `/shiro-cas` within the current application.
+* `security.shiro.cas.failurePath` (OPTIONAL): Optional with a multi-domain configuration. This path is appended to the server's base-URL when constructing `security.shiro.cas.failureUrl`, the URL that users are redirected to if ticket validation fails.
 
 ## Example configuration
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ security.shiro.cas.serviceUrl='https://apps.example.com/my-app/shiro-cas'
 Assuming that:
 * your end-users use more than one domain to access the application
 * your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
-* your Grails application is accessed via a load-balancer at https://\*.example.com/my-app, where `\*` indicates a wildcard.
+* your Grails application is accessed via a load-balancer at https://\*.example.com/my-app, where \* indicates a wildcard.
 
 A valid configuration would be:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ security.shiro.cas.serviceUrl='https://apps.example.com/my-app/shiro-cas'
 Assuming that:
 * your end-users use more than one domain to access the application
 * your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
-* your Grails application is accessed via a load-balancer at https://*.example.com/my-app, where `*` indicates a wildcard.
+* your Grails application is accessed via a load-balancer at https://\*.example.com/my-app, where `\*` indicates a wildcard.
 
 A valid configuration would be:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 * `security.shiro.cas.singleSignOut.disabled` (OPTIONAL): Boolean value controlling whether to disable Single Sign Out.  By default, this is `false`, resulting in Single Sign Out support being enabled (matching the default for CAS).  Note that this configuration value is used at build-time to modify the `web.xml`, and externalized configuration will not be taken into account during that phase.
 * `security.shiro.cas.singleSignOut.artifactParameterName` (OPTIONAL): The parameter used to detect sessions in preparation for Single Sign Out support.  By default, this is `ticket` (matching the default for CAS).
 * `security.shiro.cas.singleSignOut.logoutParameterName` (OPTIONAL): The parameter used to detect logout requests.  By default, this is `logoutRequest` (matching the default for CAS).
+* `security.shiro.cas.dynamicServerName` (OPTIONAL): The parameter used to denote a multi-domain server. Parameters `security.shiro.cas.serviceUri` and `security.shiro.cas.failureUri` are required if `true`. By default, this is `false`.
+* `security.shiro.cas.serviceUri` (OPTIONAL): REQUIRED if `security.shiro.cas.dynamicServerName` is `true`. This URI is appended to the server's base-URL when constructing `security.shiro.cas.serviceUrl`. This should be the path relative to the server at which end-users can reach `/shiro-cas` within the current application.
+* `security.shiro.cas.failureUri` (OPTIONAL): This URI is appended to the server's base-URL when constructing `security.shiro.cas.failureUrl`, the URL that users are redirected to if ticket validation fails.
 
 ## Example configuration
 
@@ -37,6 +40,21 @@ A valid configuration would be:
 ```groovy
 security.shiro.cas.serverUrl='https://sso.example.com/cas'
 security.shiro.cas.serviceUrl='https://apps.example.com/my-app/shiro-cas'
+```
+
+### Example multi-domain configuration
+Assuming that:
+* your end-users use more than one domain to access the application
+* your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
+* your Grails application is accessed via a load-balancer at https://*.example.com/my-app, where `*` indicates a wildcard.
+
+A valid configuration would be:
+
+```groovy
+security.shiro.cas.dynamicServerName=true
+security.shiro.cas.serviceUri='/my-app/shiro-cas'
+security.shiro.cas.serverUrl='https://sso.example.com/cas'
+security.shiro.cas.serviceUrl='https://default.example.com' + security.shiro.cas.serviceUri //default serviceUrl
 ```
 
 # Accessing URLs

--- a/ShiroCasGrailsPlugin.groovy
+++ b/ShiroCasGrailsPlugin.groovy
@@ -36,7 +36,7 @@ class ShiroCasGrailsPlugin {
         shiroSecurityManager.propertyValues.add("subjectFactory", casSubjectFactory)
         if (!securityConfig.filter.config) {
 
-            if(ShiroCasConfigUtils.hasDynamicServerName){
+            if(ShiroCasConfigUtils.isServerNameDynamic()){
                 casFilter(DynamicServerNameCasFilter)
             }
             else{

--- a/ShiroCasGrailsPlugin.groovy
+++ b/ShiroCasGrailsPlugin.groovy
@@ -36,14 +36,9 @@ class ShiroCasGrailsPlugin {
         shiroSecurityManager.propertyValues.add("subjectFactory", casSubjectFactory)
         if (!securityConfig.filter.config) {
 
-            if(ShiroCasConfigUtils.isServerNameDynamic()){
-                casFilter(DynamicServerNameCasFilter)
-            }
-            else{
-                casFilter(CasFilter) { bean ->
-                    if (ShiroCasConfigUtils.failureUrl) {
-                        failureUrl = ShiroCasConfigUtils.failureUrl
-                    }
+            casFilter(DynamicServerNameCasFilter) { bean ->
+                if (ShiroCasConfigUtils.failureUrl) {
+                    failureUrl = ShiroCasConfigUtils.failureUrl
                 }
             }
 
@@ -58,7 +53,7 @@ class ShiroCasGrailsPlugin {
             def shiroFilter = beanBuilder.getBeanDefinition("shiroFilter")
             shiroFilter.propertyValues.addPropertyValue("filterChainDefinitions", ShiroCasConfigUtils.shiroCasFilter)
             if (!securityConfig.filter.loginUrl) {
-                shiroFilter.propertyValues.addPropertyValue("loginUrl", ShiroCasConfigUtils.loginUrl)
+                shiroFilter.propertyValues.addPropertyValue("loginUrl", ShiroCasConfigUtils.getLoginUrl())
             }
         }
     }

--- a/ShiroCasGrailsPlugin.groovy
+++ b/ShiroCasGrailsPlugin.groovy
@@ -1,6 +1,7 @@
 import grails.spring.BeanBuilder
 import org.apache.shiro.cas.CasFilter
 import org.apache.shiro.cas.CasSubjectFactory
+import org.apache.shiro.cas.grails.DynamicServerNameCasFilter
 import org.apache.shiro.cas.grails.ShiroCasConfigUtils
 import org.jasig.cas.client.session.SingleSignOutFilter
 import org.jasig.cas.client.session.SingleSignOutHttpSessionListener
@@ -34,11 +35,18 @@ class ShiroCasGrailsPlugin {
         def shiroSecurityManager = beanBuilder.getBeanDefinition("shiroSecurityManager")
         shiroSecurityManager.propertyValues.add("subjectFactory", casSubjectFactory)
         if (!securityConfig.filter.config) {
-            casFilter(CasFilter) { bean ->
-                if (ShiroCasConfigUtils.failureUrl) {
-                    failureUrl = ShiroCasConfigUtils.failureUrl
+
+            if(ShiroCasConfigUtils.hasDynamicServerName){
+                casFilter(DynamicServerNameCasFilter)
+            }
+            else{
+                casFilter(CasFilter) { bean ->
+                    if (ShiroCasConfigUtils.failureUrl) {
+                        failureUrl = ShiroCasConfigUtils.failureUrl
+                    }
                 }
             }
+
             if (!ShiroCasConfigUtils.singleSignOutDisabled) {
                 singleSignOutFilter(SingleSignOutFilter) { bean ->
                     ignoreInitConfiguration = true
@@ -46,6 +54,7 @@ class ShiroCasGrailsPlugin {
                     logoutParameterName = ShiroCasConfigUtils.singleSignOutLogoutParameterName
                 }
             }
+
             def shiroFilter = beanBuilder.getBeanDefinition("shiroFilter")
             shiroFilter.propertyValues.addPropertyValue("filterChainDefinitions", ShiroCasConfigUtils.shiroCasFilter)
             if (!securityConfig.filter.loginUrl) {

--- a/src/groovy/org/apache/shiro/cas/grails/DynamicServerNameCasFilter.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/DynamicServerNameCasFilter.groovy
@@ -1,0 +1,45 @@
+package org.apache.shiro.cas.grails
+
+import org.apache.shiro.authc.AuthenticationException
+import org.apache.shiro.authc.AuthenticationToken
+import org.apache.shiro.cas.CasFilter
+import org.apache.shiro.subject.Subject
+import org.apache.shiro.web.util.WebUtils
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+
+class DynamicServerNameCasFilter extends CasFilter {
+
+    @Override
+    protected boolean onLoginFailure(AuthenticationToken token, AuthenticationException ae, ServletRequest request,
+                                     ServletResponse response) {
+
+        Logger logger = LoggerFactory.getLogger(CasFilter.class);
+        
+        //FailureUrl changes depending on the domain the request was to.
+        Subject subject = getSubject(request, response);
+        if (subject.isAuthenticated() || subject.isRemembered()) {
+            try {
+                issueSuccessRedirect(request, response);
+            } catch (Exception e) {
+                logger.error("Cannot redirect to the default success url", e);
+            }
+        } else {
+            try {
+                WebUtils.issueRedirect(request, response, ShiroCasConfigUtils.failureUrl);
+            } catch (IOException e) {
+                logger.error("Cannot redirect to failure url : {}", ShiroCasConfigUtils.failureUrl, e);
+            }
+        }
+        
+        return false;
+    }
+    
+    @Override
+    public String getLoginUrl() {
+        return ShiroCasConfigUtils.loginUrl
+    }
+}

--- a/src/groovy/org/apache/shiro/cas/grails/DynamicServerNameCasFilter.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/DynamicServerNameCasFilter.groovy
@@ -1,38 +1,41 @@
 package org.apache.shiro.cas.grails
 
+import groovy.util.logging.Slf4j
 import org.apache.shiro.authc.AuthenticationException
 import org.apache.shiro.authc.AuthenticationToken
 import org.apache.shiro.cas.CasFilter
 import org.apache.shiro.subject.Subject
 import org.apache.shiro.web.util.WebUtils
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 
+@Slf4j
 class DynamicServerNameCasFilter extends CasFilter {
 
     @Override
     protected boolean onLoginFailure(AuthenticationToken token, AuthenticationException ae, ServletRequest request,
                                      ServletResponse response) {
-
-        Logger logger = LoggerFactory.getLogger(CasFilter.class);
         
-        //FailureUrl changes depending on the domain the request was to.
-        Subject subject = getSubject(request, response);
-        if (subject.isAuthenticated() || subject.isRemembered()) {
-            try {
-                issueSuccessRedirect(request, response);
-            } catch (Exception e) {
-                logger.error("Cannot redirect to the default success url", e);
+        if(ShiroCasConfigUtils.isServerNameDynamic()) {
+            //FailureUrl changes depending on the domain the request was to.
+            Subject subject = getSubject(request, response);
+            if (subject.isAuthenticated() || subject.isRemembered()) {
+                try {
+                    issueSuccessRedirect(request, response);
+                } catch (Exception e) {
+                    log.error("Cannot redirect to the default success url", e);
+                }
+            } else {
+                try {
+                    WebUtils.issueRedirect(request, response, ShiroCasConfigUtils.failureUrl);
+                } catch (IOException e) {
+                    log.error("Cannot redirect to failure url : {}", ShiroCasConfigUtils.failureUrl, e);
+                }
             }
-        } else {
-            try {
-                WebUtils.issueRedirect(request, response, ShiroCasConfigUtils.failureUrl);
-            } catch (IOException e) {
-                logger.error("Cannot redirect to failure url : {}", ShiroCasConfigUtils.failureUrl, e);
-            }
+        }
+        else{
+           return super.onLoginFailure(token, ae, request, response)
         }
         
         return false;
@@ -40,6 +43,6 @@ class DynamicServerNameCasFilter extends CasFilter {
     
     @Override
     public String getLoginUrl() {
-        return ShiroCasConfigUtils.loginUrl
+        return ShiroCasConfigUtils.getLoginUrl()
     }
 }

--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
@@ -4,6 +4,9 @@ import grails.util.Holders
 import groovy.transform.PackageScope
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
+import org.apache.shiro.SecurityUtils
+import org.apache.shiro.UnavailableSecurityManagerException
+import org.apache.shiro.web.util.WebUtils
 import org.springframework.web.util.UriComponentsBuilder
 
 class ShiroCasConfigUtils {
@@ -11,56 +14,119 @@ class ShiroCasConfigUtils {
     static Log log = LogFactory.getLog(ShiroCasConfigUtils)
 
     static String serverUrl
-    static String serviceUrl
-    static String loginUrl
-    static String logoutUrl
-    static String failureUrl
+    private static String serviceUrl
+    private static String loginUrl
+    private static String logoutUrl
+    private static String failureUrl
+    private static String serviceUri
+    private static String failureUri
+    private static boolean dynamicServerName
     static String singleSignOutArtifactParameterName
     static String singleSignOutLogoutParameterName
     private static String filterChainDefinitions
+    private static ConfigObject casConfig
 
     static void initialize(ConfigObject config) {
-        def casConfig = config.security.shiro.cas
-        serverUrl = stripTrailingSlash(casConfig.serverUrl ?: "")
-        serviceUrl = stripTrailingSlash(casConfig.serviceUrl ?: "")
-        loginUrl = serverUrl ? assembleLoginUrl(casConfig) : ""
-        logoutUrl = serverUrl ? assembleLogoutUrl(casConfig) : ""
-        failureUrl = casConfig.failureUrl ?: null
+        casConfig = config.security.shiro.cas
+
         singleSignOutArtifactParameterName = casConfig.singleSignOut.artifactParameterName ?: "ticket"
         singleSignOutLogoutParameterName = casConfig.singleSignOut.logoutParameterName ?: "logoutRequest"
         filterChainDefinitions = config.security.shiro.filter.filterChainDefinitions ?: ""
+        dynamicServerName = casConfig.dynamicServerName ?: false
+        serverUrl = stripTrailingSlash(casConfig.serverUrl ?: "")
+        serviceUrl = stripTrailingSlash(casConfig.serviceUrl ?: "")
+        failureUrl = casConfig.failureUrl ?: null
+
+        if(dynamicServerName){
+            serviceUri = stripTrailingSlash(casConfig.serviceUri ?: "")
+            failureUri = casConfig.failureUri ?: null
+            loginUrl = ""
+            logoutUrl = ""
+
+            if (!serviceUri) {
+                log.error("Invalid application configuration: security.shiro.cas.serviceUri is required when enabling security.shiro.cas.dynamicServerName; it should be /mycontextpath/shiro-cas")
+            }
+        }
+        else{
+            loginUrl = serverUrl ? assembleLoginUrl() : ""
+            logoutUrl = serverUrl ? assembleLogoutUrl() : ""
+        }
+
         if (!serverUrl) {
             log.error("Invalid application configuration: security.shiro.cas.serverUrl is required; it should be https://host:port/cas")
         }
         if (!serviceUrl) {
             log.error("Invalid application configuration: security.shiro.cas.serviceUrl is required; it should be http://host:port/mycontextpath/shiro-cas")
         }
+
+    }
+
+    static String getServiceUrl() {
+        if(dynamicServerName && serviceUri){
+            try{
+                def httpRequest = WebUtils.getHttpRequest(SecurityUtils.getSubject())
+                if(httpRequest) {
+                    def builder = UriComponentsBuilder.fromHttpUrl(getBaseUrl(httpRequest)).path(serviceUri)
+                    return builder.build().encode().toUriString()
+                }
+            }catch(UnavailableSecurityManagerException ex){
+                log.info("Unable to get a dynamic serviceUrl, reverting to default.", ex)
+            }
+        }
+
+        return serviceUrl
+    }
+
+    static String getFailureUrl() {
+        if(dynamicServerName && failureUri){
+            try{
+                def httpRequest = WebUtils.getHttpRequest(SecurityUtils.getSubject())
+                if(httpRequest) {
+                    def builder = UriComponentsBuilder.fromHttpUrl(getBaseUrl(httpRequest)).path(failureUri)
+                    return builder.build().encode().toUriString()
+                }
+            }catch(UnavailableSecurityManagerException ex){
+                log.info("Unable to get a dynamic failureUrl, reverting to default.", ex)
+            }
+        }
+
+        return failureUrl
+    }
+
+    static String getLoginUrl() {
+        return dynamicServerName? assembleLoginUrl() : loginUrl
+    }
+
+    static String getLogoutUrl() {
+        return dynamicServerName? assembleLogoutUrl() : logoutUrl
     }
 
     static boolean isSingleSignOutDisabled() {
         return Holders.config.security.shiro.cas.singleSignOut.disabled ?: false
     }
 
-    private static String assembleLoginUrl(ConfigObject casConfig) {
-        def params = casConfig.loginParameters
-        def builder = casConfig.loginUrl ?
+    private static String assembleLoginUrl() {
+        def builder = casConfig?.loginUrl ?
                 UriComponentsBuilder.fromHttpUrl(casConfig.loginUrl) :
-                UriComponentsBuilder.fromHttpUrl(serverUrl).path("/login").queryParam("service", serviceUrl)
+                UriComponentsBuilder.fromHttpUrl(serverUrl).path("/login").queryParam("service", getServiceUrl())
+
+        def params = casConfig?.loginParameters
         if (params) {
             params.each { name, value ->
                 builder.queryParam(name, value)
             }
         }
+
         return builder.build().encode().toUriString()
     }
 
-    private static String assembleLogoutUrl(ConfigObject casConfig) {
-        def builder = casConfig.logoutUrl ?
+    private static String assembleLogoutUrl() {
+        def builder = casConfig?.logoutUrl ?
                 UriComponentsBuilder.fromHttpUrl(casConfig.logoutUrl) :
-                UriComponentsBuilder.fromHttpUrl(serverUrl).path("/logout").queryParam("service", serviceUrl)
+                UriComponentsBuilder.fromHttpUrl(serverUrl).path("/logout").queryParam("service", getServiceUrl())
         return builder.build().encode().toUriString()
     }
-    
+
     static String getShiroCasFilter() {
         def filters = new StringBuilder()
         if (!isSingleSignOutDisabled()) {
@@ -76,5 +142,9 @@ class ShiroCasConfigUtils {
 
     private static String stripTrailingSlash(String url) {
         return url?.endsWith("/") ? url[0..-2] : url
+    }
+
+    private static String getBaseUrl(request){
+        return request.getScheme() + "://" + request.getServerName() + (("http".equals(request.getScheme()) && request.getServerPort() == 80 || "https".equals(request.getScheme()) && request.getServerPort() == 443) ? "" : (":" + request.getServerPort()) )
     }
 }

--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasUrlBuilder.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasUrlBuilder.groovy
@@ -33,10 +33,10 @@ class ShiroCasUrlBuilder {
     }
 
     static ShiroCasUrlBuilder forLogin() {
-        return new ShiroCasUrlBuilder(ShiroCasConfigUtils.loginUrl)
+        return new ShiroCasUrlBuilder(ShiroCasConfigUtils.getLoginUrl())
     }
 
     static ShiroCasUrlBuilder forLogout() {
-        return new ShiroCasUrlBuilder(ShiroCasConfigUtils.logoutUrl)
+        return new ShiroCasUrlBuilder(ShiroCasConfigUtils.getLogoutUrl())
     }
 }

--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasUtils.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasUtils.groovy
@@ -9,7 +9,7 @@ final class ShiroCasUtils {
 
     static void redirectToCasLogin(FilterConfig filter) {
         WebUtils.saveRequest(new TweakedRequest(filter.request))
-        filter.redirect(uri: ShiroCasConfigUtils.loginUrl)
+        filter.redirect(uri: ShiroCasConfigUtils.getLoginUrl())
     }
 
     /**
@@ -23,7 +23,7 @@ final class ShiroCasUtils {
         def subject = SecurityUtils.subject
         def principal = subject?.principal
         subject?.logout()
-        def destinationUrl = ShiroCasPrincipalManager.isFromCas(principal) ? ShiroCasConfigUtils.logoutUrl : defaultLogoutUrl
+        def destinationUrl = ShiroCasPrincipalManager.isFromCas(principal) ? ShiroCasConfigUtils.getLogoutUrl() : defaultLogoutUrl
         ShiroCasPrincipalManager.forgetPrincipal(principal)
         return destinationUrl
     }

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -171,8 +171,8 @@ security.shiro.cas.singleSignOut.disabled = true
         init("""
 security.shiro.cas.serverUrl = "https://localhost/cas"
 security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
-security.shiro.cas.serviceUri = "/test/shiro-cas"
-security.shiro.cas.failureUri = "/test/"
+security.shiro.cas.servicePath = "/test/shiro-cas"
+security.shiro.cas.failurePath = "/test/"
 security.shiro.cas.dynamicServerName = true
         """)
 
@@ -191,19 +191,6 @@ security.shiro.cas.dynamicServerName = true
         2 * httpServletRequest.getServerName() >> secondDomain
         secondServiceUrl == "http://" + secondDomain + "/test/shiro-cas"
         secondFailureUrl == "http://" + secondDomain + "/test/"
-    }
-
-    void "dynamicServerName option requires serviceUri"(){
-
-        when: "initialized with an invalid dynamicServerName configuration (without serviceUri)"
-        init("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
-security.shiro.cas.dynamicServerName = true
-        """)
-
-        then: "throws an error"
-        1 * mockLog.error(_)
     }
 
     static void init(String script) {

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -178,13 +178,13 @@ security.shiro.cas.failurePath = "/test/"
         def secondFailureUrl = ShiroCasConfigUtils.failureUrl
 
         then: "URLs overwridden using first domain"
-        3 * httpServletRequest.getRequestURL() >> new StringBuffer(firstUrl)
+        2 * httpServletRequest.getRequestURL() >> new StringBuffer(firstUrl)
         firstServiceUrl == firstUrl + "/test/shiro-cas"
         firstFailureUrl == firstUrl + "/test/"
 
 
         then: "URLs overwridden using second domain"
-        3 * httpServletRequest.getRequestURL() >> new StringBuffer(secondUrl)
+        2 * httpServletRequest.getRequestURL() >> new StringBuffer(secondUrl)
         secondServiceUrl == secondUrl + "/test/shiro-cas"
         secondFailureUrl == secondUrl + "/test/"
     }

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -76,7 +76,6 @@ security.shiro.cas.loginUrl = "https://cas.example.com/customLogin"
 security.shiro.cas.logoutUrl = "https://cas.example.com/customLogout"
 security.shiro.cas.failureUrl = "https://app.example.com/casFailure"
 security.shiro.filter.filterChainDefinitions = "/other=otherFilter"
-security.shiro.filter.dynamicServerName = false
 security.shiro.cas.loginParameters.renew = true
 security.shiro.cas.singleSignOut.disabled = false
 security.shiro.cas.singleSignOut.artifactParameterName = "token"
@@ -173,7 +172,6 @@ security.shiro.cas.serverUrl = "https://localhost/cas"
 security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
 security.shiro.cas.servicePath = "/test/shiro-cas"
 security.shiro.cas.failurePath = "/test/"
-security.shiro.cas.dynamicServerName = true
         """)
 
         def firstServiceUrl = ShiroCasConfigUtils.serviceUrl

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -155,14 +155,12 @@ security.shiro.cas.singleSignOut.disabled = true
 
     void "dynamicServerName option handles multiple server names"(){
         setup:
-        def firstDomain = "test.server.com"
-        def secondDomain = "anothertest.server.com"
+        def firstUrl = "http://test.server.com"
+        def secondUrl = "http://anothertest.server.com"
 
         GroovyMock(SecurityUtils, global: true)
         GroovyMock(WebUtils, global: true)
         def httpServletRequest = Mock(HttpServletRequest)
-        httpServletRequest.getScheme() >> "http"
-        httpServletRequest.getServerPort() >> 80
         WebUtils.getHttpRequest(_) >> httpServletRequest
 
 
@@ -180,15 +178,15 @@ security.shiro.cas.failurePath = "/test/"
         def secondFailureUrl = ShiroCasConfigUtils.failureUrl
 
         then: "URLs overwridden using first domain"
-        2 * httpServletRequest.getServerName() >> firstDomain
-        firstServiceUrl == "http://" + firstDomain + "/test/shiro-cas"
-        firstFailureUrl == "http://" + firstDomain + "/test/"
+        3 * httpServletRequest.getRequestURL() >> new StringBuffer(firstUrl)
+        firstServiceUrl == firstUrl + "/test/shiro-cas"
+        firstFailureUrl == firstUrl + "/test/"
 
 
         then: "URLs overwridden using second domain"
-        2 * httpServletRequest.getServerName() >> secondDomain
-        secondServiceUrl == "http://" + secondDomain + "/test/shiro-cas"
-        secondFailureUrl == "http://" + secondDomain + "/test/"
+        3 * httpServletRequest.getRequestURL() >> new StringBuffer(secondUrl)
+        secondServiceUrl == secondUrl + "/test/shiro-cas"
+        secondFailureUrl == secondUrl + "/test/"
     }
 
     static void init(String script) {

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -153,7 +153,7 @@ security.shiro.cas.singleSignOut.disabled = true
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=casFilter\n"
     }
 
-    void "dynamicServerName option handles multiple server names"(){
+    void "enabling isServerNameDynamic handles multiple server names"(){
         setup:
         def firstUrl = "http://test.server.com"
         def secondUrl = "http://anothertest.server.com"
@@ -177,13 +177,15 @@ security.shiro.cas.failurePath = "/test/"
         def secondServiceUrl = ShiroCasConfigUtils.serviceUrl
         def secondFailureUrl = ShiroCasConfigUtils.failureUrl
 
-        then: "URLs overwridden using first domain"
+        then: "initialized"
+        2 * httpServletRequest.getRequestURL() >> new StringBuffer("http://default.com")
+        
+        then: "URLs overridden using first domain"
         2 * httpServletRequest.getRequestURL() >> new StringBuffer(firstUrl)
         firstServiceUrl == firstUrl + "/test/shiro-cas"
         firstFailureUrl == firstUrl + "/test/"
 
-
-        then: "URLs overwridden using second domain"
+        then: "URLs overridden using second domain"
         2 * httpServletRequest.getRequestURL() >> new StringBuffer(secondUrl)
         secondServiceUrl == secondUrl + "/test/shiro-cas"
         secondFailureUrl == secondUrl + "/test/"

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -177,9 +177,6 @@ security.shiro.cas.failurePath = "/test/"
         def secondServiceUrl = ShiroCasConfigUtils.serviceUrl
         def secondFailureUrl = ShiroCasConfigUtils.failureUrl
 
-        then: "initialized"
-        2 * httpServletRequest.getRequestURL() >> new StringBuffer("http://default.com")
-        
         then: "URLs overridden using first domain"
         2 * httpServletRequest.getRequestURL() >> new StringBuffer(firstUrl)
         firstServiceUrl == firstUrl + "/test/shiro-cas"


### PR DESCRIPTION
Adds three new config params to support servers running the grails-shiro-cas plugin that have applications using more than one domain name.

* `security.shiro.cas.dynamicServerName` (OPTIONAL): The parameter used to denote a multi-domain server. Parameters `security.shiro.cas.serviceUri` and `security.shiro.cas.failureUri` are required if `true`. By default, this is `false`.
* `security.shiro.cas.serviceUri` (OPTIONAL): REQUIRED if `security.shiro.cas.dynamicServerName` is `true`. This URI is appended to the server's base-URL when constructing `security.shiro.cas.serviceUrl`. This should be the path relative to the server at which end-users can reach `/shiro-cas` within the current application.
* `security.shiro.cas.failureUri` (OPTIONAL): This URI is appended to the server's base-URL when constructing `security.shiro.cas.failureUrl`, the URL that users are redirected to if ticket validation fails.