### PR TITLE
Unifying configuration for single/multi domain, Spock test cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 * `security.shiro.cas.singleSignOut.disabled` (OPTIONAL): Boolean value controlling whether to disable Single Sign Out.  By default, this is `false`, resulting in Single Sign Out support being enabled (matching the default for CAS).  Note that this configuration value is used at build-time to modify the `web.xml`, and externalized configuration will not be taken into account during that phase.
 * `security.shiro.cas.singleSignOut.artifactParameterName` (OPTIONAL): The parameter used to detect sessions in preparation for Single Sign Out support.  By default, this is `ticket` (matching the default for CAS).
 * `security.shiro.cas.singleSignOut.logoutParameterName` (OPTIONAL): The parameter used to detect logout requests.  By default, this is `logoutRequest` (matching the default for CAS).
-* `security.shiro.cas.multiDomain` (OPTIONAL): Set to `true` for a multi-domain scenario. This will result in the server's base URL being substituted for the `security.shiro.cas.baseServiceUrl` if available.
 
 ## Example configuration
 
 Assuming that:
 * your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
-* your Grails application is accessed via a load-balancer at https://apps.example.com/my-app
+* your Grails application is accessed at https://apps.example.com/my-app
 
 A valid configuration would be:
 
@@ -42,20 +41,14 @@ security.shiro.cas.baseServiceUrl='https://apps.example.com/'
 security.shiro.cas.servicePath='/my-app/shiro-cas'
 ```
 
-### Example multi-domain configuration
+### Multi-domain Support
+
 Assuming that:
 * your end-users use more than one domain to access the application
 * your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
 * your Grails application is accessed via a load-balancer at https://\*.example.com/my-app, where \* indicates a wildcard.
 
-Simply add `security.shiro.cas.multiDomain=true` to your existing configuration:
-
-```groovy
-security.shiro.cas.serverUrl='https://sso.example.com/cas'
-security.shiro.cas.baseServiceUrl='https://apps.example.com/'
-security.shiro.cas.servicePath='/my-app/shiro-cas'
-security.shiro.cas.multiDomain=true
-```
+This plugin will automatically use the service base URL from the request, and return to the requesting service.
 
 # Accessing URLs
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 * `security.shiro.cas.failureUrl` (RECOMMENDED): The URL that users are redirected to if ticket validation fails.  If this is not specified, ticket validation failures will result in `NullPointerException`s being thrown.
 * `security.shiro.cas.loginUrl` (OPTIONAL): The URL that users are redirected to when login is required.  By default, this directs users to `/login` within the `serverUrl`, passing along the service as a query parameter.
 * `security.shiro.cas.logoutUrl` (OPTIONAL): The URL that users are redirected to when logging out.  By default, this directs users to `/logout` within the `serverUrl`, passing along the service as a query parameter.
-* `security.shiro.cas.loginParameters` (OPTIONAL): Key, Value pairs to be added to the generated or explicitly set loginUrl. (see [CAS Parameters](http://www.jasig.org/cas/protocol#parameters) for more details on how this is used) 
+* `security.shiro.cas.loginParameters` (OPTIONAL): Key, Value pairs to be added to the generated or explicitly set loginUrl. (see [CAS Parameters](http://www.jasig.org/cas/protocol#parameters) for more details on how this is used)
 * `security.shiro.cas.singleSignOut.disabled` (OPTIONAL): Boolean value controlling whether to disable Single Sign Out.  By default, this is `false`, resulting in Single Sign Out support being enabled (matching the default for CAS).  Note that this configuration value is used at build-time to modify the `web.xml`, and externalized configuration will not be taken into account during that phase.
 * `security.shiro.cas.singleSignOut.artifactParameterName` (OPTIONAL): The parameter used to detect sessions in preparation for Single Sign Out support.  By default, this is `ticket` (matching the default for CAS).
 * `security.shiro.cas.singleSignOut.logoutParameterName` (OPTIONAL): The parameter used to detect logout requests.  By default, this is `logoutRequest` (matching the default for CAS).
@@ -38,7 +38,8 @@ A valid configuration would be:
 
 ```groovy
 security.shiro.cas.serverUrl='https://sso.example.com/cas'
-security.shiro.cas.serviceUrl='https://apps.example.com/my-app/shiro-cas'
+security.shiro.cas.baseServiceUrl='https://apps.example.com/my-app/'
+security.shiro.cas.servicePath='/shiro-cas'
 ```
 
 ### Example multi-domain configuration
@@ -47,12 +48,13 @@ Assuming that:
 * your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
 * your Grails application is accessed via a load-balancer at https://\*.example.com/my-app, where \* indicates a wildcard.
 
-A valid configuration would be:
+Simply add `security.shiro.cas.multiDomain=true` to your existing configuration:
 
 ```groovy
-security.shiro.cas.servicePath='/my-app/shiro-cas'
 security.shiro.cas.serverUrl='https://sso.example.com/cas'
-security.shiro.cas.serviceUrl='https://default.example.com' + security.shiro.cas.servicePath //default serviceUrl
+security.shiro.cas.baseServiceUrl='https://apps.example.com/my-app/'
+security.shiro.cas.servicePath='/shiro-cas'
+security.shiro.cas.multiDomain=true
 ```
 
 # Accessing URLs

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 # Configuration
 
 * `security.shiro.cas.serverUrl` (REQUIRED): The URL of the CAS instance to authenticate against.  This should be an HTTPS URL.
-* `security.shiro.cas.serviceUrl` (REQUIRED): The URL to pass to CAS as the `service` parameter (see [CAS Protocol](http://www.jasig.org/cas/protocol) for more details on how this is used).  This should be the URL at which end-users can reach the `/shiro-cas` path within the current application (which is automatically registered by this plugin).
-* `security.shiro.cas.failureUrl` (RECOMMENDED): The URL that users are redirected to if ticket validation fails.  If this is not specified, ticket validation failures will result in `NullPointerException`s being thrown.
+* `security.shiro.cas.baseServiceUrl` (REQUIRED): The base URL to pass to CAS as the `service` parameter (see [CAS Protocol](http://www.jasig.org/cas/protocol) for more details on how this is used).  This should be the protocol/host/port portion of your application server's URL.
+* `security.shiro.cas.servicePath` (REQUIRED): This should be the path at which end-users can reach the `/my-app/shiro-cas` path within the current application (which is automatically registered by this plugin).
+* `security.shiro.cas.failurePath` (RECOMMENDED): The path that users are redirected to if ticket validation fails.  If this is not specified, ticket validation failures will result in `NullPointerException`s being thrown.
 * `security.shiro.cas.loginUrl` (OPTIONAL): The URL that users are redirected to when login is required.  By default, this directs users to `/login` within the `serverUrl`, passing along the service as a query parameter.
 * `security.shiro.cas.logoutUrl` (OPTIONAL): The URL that users are redirected to when logging out.  By default, this directs users to `/logout` within the `serverUrl`, passing along the service as a query parameter.
 * `security.shiro.cas.loginParameters` (OPTIONAL): Key, Value pairs to be added to the generated or explicitly set loginUrl. (see [CAS Parameters](http://www.jasig.org/cas/protocol#parameters) for more details on how this is used)
 * `security.shiro.cas.singleSignOut.disabled` (OPTIONAL): Boolean value controlling whether to disable Single Sign Out.  By default, this is `false`, resulting in Single Sign Out support being enabled (matching the default for CAS).  Note that this configuration value is used at build-time to modify the `web.xml`, and externalized configuration will not be taken into account during that phase.
 * `security.shiro.cas.singleSignOut.artifactParameterName` (OPTIONAL): The parameter used to detect sessions in preparation for Single Sign Out support.  By default, this is `ticket` (matching the default for CAS).
 * `security.shiro.cas.singleSignOut.logoutParameterName` (OPTIONAL): The parameter used to detect logout requests.  By default, this is `logoutRequest` (matching the default for CAS).
-* `security.shiro.cas.servicePath` (OPTIONAL): Required for a multi-domain configuration. This path is appended to the server's base-URL when constructing `security.shiro.cas.serviceUrl`. This should be the path relative to the server at which end-users can reach `/shiro-cas` within the current application.
-* `security.shiro.cas.failurePath` (OPTIONAL): Optional with a multi-domain configuration. This path is appended to the server's base-URL when constructing `security.shiro.cas.failureUrl`, the URL that users are redirected to if ticket validation fails.
+* `security.shiro.cas.multiDomain` (OPTIONAL): Set to `true` for a multi-domain scenario. This will result in the server's base URL being substituted for the `security.shiro.cas.baseServiceUrl` if available.
 
 ## Example configuration
 
@@ -38,8 +38,8 @@ A valid configuration would be:
 
 ```groovy
 security.shiro.cas.serverUrl='https://sso.example.com/cas'
-security.shiro.cas.baseServiceUrl='https://apps.example.com/my-app/'
-security.shiro.cas.servicePath='/shiro-cas'
+security.shiro.cas.baseServiceUrl='https://apps.example.com/'
+security.shiro.cas.servicePath='/my-app/shiro-cas'
 ```
 
 ### Example multi-domain configuration
@@ -52,8 +52,8 @@ Simply add `security.shiro.cas.multiDomain=true` to your existing configuration:
 
 ```groovy
 security.shiro.cas.serverUrl='https://sso.example.com/cas'
-security.shiro.cas.baseServiceUrl='https://apps.example.com/my-app/'
-security.shiro.cas.servicePath='/shiro-cas'
+security.shiro.cas.baseServiceUrl='https://apps.example.com/'
+security.shiro.cas.servicePath='/my-app/shiro-cas'
 security.shiro.cas.multiDomain=true
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 # Configuration
 
 * `security.shiro.cas.serverUrl` (REQUIRED): The URL of the CAS instance to authenticate against.  This should be an HTTPS URL.
-* `security.shiro.cas.baseServiceUrl` (REQUIRED): The base URL to pass to CAS as the `service` parameter (see [CAS Protocol](http://www.jasig.org/cas/protocol) for more details on how this is used).  This should be the protocol/host/port portion of your application server's URL.
-* `security.shiro.cas.servicePath` (REQUIRED): This should be the path at which end-users can reach the `/my-app/shiro-cas` path within the current application (which is automatically registered by this plugin).
+* `security.shiro.cas.baseServiceUrl` (OPTIONAL): The base URL to pass to CAS as the `service` parameter (see [CAS Protocol](http://www.jasig.org/cas/protocol) for more details on how this is used).  This should be the protocol/host/port portion of your application server's URL with the application context. If unset, the plugin will attempt to determine the base URL dynamically.
+* `security.shiro.cas.servicePath` (OPTIONAL): This should be the path at which end-users can reach the `/shiro-cas` path within the current application (which is automatically registered by this plugin). Defaults to `/shiro-cas`.
 * `security.shiro.cas.failurePath` (RECOMMENDED): The path that users are redirected to if ticket validation fails.  If this is not specified, ticket validation failures will result in `NullPointerException`s being thrown.
 * `security.shiro.cas.loginUrl` (OPTIONAL): The URL that users are redirected to when login is required.  By default, this directs users to `/login` within the `serverUrl`, passing along the service as a query parameter.
 * `security.shiro.cas.logoutUrl` (OPTIONAL): The URL that users are redirected to when logging out.  By default, this directs users to `/logout` within the `serverUrl`, passing along the service as a query parameter.
@@ -26,6 +26,15 @@ Finally, you need a CAS-enabled Shiro realm.  Run `grails create-cas-realm` to c
 * `security.shiro.cas.singleSignOut.disabled` (OPTIONAL): Boolean value controlling whether to disable Single Sign Out.  By default, this is `false`, resulting in Single Sign Out support being enabled (matching the default for CAS).  Note that this configuration value is used at build-time to modify the `web.xml`, and externalized configuration will not be taken into account during that phase.
 * `security.shiro.cas.singleSignOut.artifactParameterName` (OPTIONAL): The parameter used to detect sessions in preparation for Single Sign Out support.  By default, this is `ticket` (matching the default for CAS).
 * `security.shiro.cas.singleSignOut.logoutParameterName` (OPTIONAL): The parameter used to detect logout requests.  By default, this is `logoutRequest` (matching the default for CAS).
+
+## Sane defaults
+
+Assuming that:
+* your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
+* your Grails application is accessed at https://apps.example.com/my-app
+* your service endpoint exists at https://apps.example.com/my-app/shiro-cas
+
+The only required configuration parameter for this plugin is `security.shiro.cas.serverUrl` -- the plugin will attempt to determine the  `baseServiceUrl` dynamically, if not set. It will use `/shiro-cas` as the default `servicePath`.
 
 ## Example configuration
 
@@ -37,8 +46,8 @@ A valid configuration would be:
 
 ```groovy
 security.shiro.cas.serverUrl='https://sso.example.com/cas'
-security.shiro.cas.baseServiceUrl='https://apps.example.com/'
-security.shiro.cas.servicePath='/my-app/shiro-cas'
+security.shiro.cas.baseServiceUrl='https://apps.example.com/my-app'
+security.shiro.cas.servicePath='/shiro-cas'
 ```
 
 ### Multi-domain Support
@@ -46,9 +55,9 @@ security.shiro.cas.servicePath='/my-app/shiro-cas'
 Assuming that:
 * your end-users use more than one domain to access the application
 * your CAS instance is deployed at context path `/cas` on `sso.example.com` on the default HTTPS port
-* your Grails application is accessed via a load-balancer at https://\*.example.com/my-app, where \* indicates a wildcard.
+* your Grails application is accessed at https://\*.example.com/my-app, where \* indicates a wildcard.
 
-This plugin will automatically use the service base URL from the request, and return to the requesting service.
+No configuration changes are required. This plugin will automatically use the service base URL from the request, and return to the requesting service.
 
 # Accessing URLs
 

--- a/ShiroCasGrailsPlugin.groovy
+++ b/ShiroCasGrailsPlugin.groovy
@@ -54,7 +54,7 @@ class ShiroCasGrailsPlugin {
             def shiroFilter = beanBuilder.getBeanDefinition("shiroFilter")
             shiroFilter.propertyValues.addPropertyValue("filterChainDefinitions", ShiroCasConfigUtils.shiroCasFilter)
             if (!securityConfig.filter.loginUrl) {
-                shiroFilter.propertyValues.addPropertyValue("loginUrl", ShiroCasConfigUtils.defaultLoginUrl)
+                shiroFilter.propertyValues.addPropertyValue("loginUrl", ShiroCasConfigUtils.loginUrl)
             }
         }
     }

--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
@@ -54,16 +54,8 @@ class ShiroCasConfigUtils {
         return failurePath ? baseServiceUrl + failurePath : ""
     }
 
-    static String getDefaultLoginUrl() {
-        return assembleLoginUrl(configuredBaseServiceUrl + servicePath)
-    }
-
     static String getLoginUrl() {
         return assembleLoginUrl(serviceUrl)
-    }
-
-    static String getDefaultLogoutUrl() {
-        return assembleLogoutUrl(configuredBaseServiceUrl + servicePath)
     }
 
     static String getLogoutUrl() {

--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
@@ -21,7 +21,6 @@ class ShiroCasConfigUtils {
     private static String defaultBaseServiceUrl
     private static String servicePath
     private static String failurePath
-    private static Boolean multiDomain
     private static Map loginParameters
     private static String singleSignOutArtifactParameterName
     private static String singleSignOutLogoutParameterName
@@ -50,7 +49,6 @@ class ShiroCasConfigUtils {
         configuredLogoutUrl = config.security.shiro.cas.logoutUrl ?: null
 
         failurePath = config.security.shiro.cas.failurePath ?: ""
-        multiDomain = config.security.shiro.cas.multiDomain
     }
 
     static private boolean minimalConfigurationValid() {
@@ -90,15 +88,13 @@ class ShiroCasConfigUtils {
     }
 
     private static String getBaseServiceUrl() {
-        if (multiDomain) {
-            try {
-                def httpRequest = WebUtils.getHttpRequest(SecurityUtils.subject)
-                if (httpRequest) {
-                    return baseUrlFromRequest(httpRequest)
-                }
-            } catch (UnavailableSecurityManagerException ex) {
-                log.debug("Unable to get a dynamic baseServiceUrl, reverting to default.", ex)
+        try {
+            def httpRequest = WebUtils.getHttpRequest(SecurityUtils.subject)
+            if (httpRequest) {
+                return baseUrlFromRequest(httpRequest)
             }
+        } catch (UnavailableSecurityManagerException ex) {
+            log.debug("Unable to get a dynamic baseServiceUrl, reverting to default.", ex)
         }
 
         return defaultBaseServiceUrl

--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
@@ -84,11 +84,7 @@ class ShiroCasConfigUtils {
             log.error("Invalid application configuration: security.shiro.cas.serverUrl is required; it should be https://host:port/cas")
         }
 
-        if (!baseServiceUrl) {
-            log.error("Invalid application configuration: security.shiro.cas.baseServiceUrl is not set, and could not be dynamically determined")
-        }
-
-        return serverUrl && baseServiceUrl
+        return serverUrl
     }
 
     private static String getBaseServiceUrl() {

--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
@@ -36,11 +36,13 @@ class ShiroCasConfigUtils {
 
     static private void processRequiredConfiguration(ConfigObject config) {
         serverUrl = stripTrailingSlash(config.security.shiro.cas.serverUrl ?: "")
-        defaultBaseServiceUrl = stripTrailingSlash(config.security.shiro.cas.baseServiceUrl ?: "")
-        servicePath = config.security.shiro.cas.servicePath ?: ""
+
+        def applicationBaseUrl = Holders.grailsApplication?.mainContext?.getBean('grailsLinkGenerator')?.serverBaseURL
+        defaultBaseServiceUrl = stripTrailingSlash(config.security.shiro.cas.baseServiceUrl ?: applicationBaseUrl)
     }
 
     static private void processOptionalConfiguration(ConfigObject config) {
+        servicePath = config.security.shiro.cas.servicePath ?: "/shiro-cas"
         singleSignOutArtifactParameterName = config.security.shiro.cas.singleSignOut.artifactParameterName ?: "ticket"
         singleSignOutLogoutParameterName = config.security.shiro.cas.singleSignOut.logoutParameterName ?: "logoutRequest"
         filterChainDefinitions = config.security.shiro.filter.filterChainDefinitions ?: ""
@@ -57,14 +59,10 @@ class ShiroCasConfigUtils {
         }
 
         if (!defaultBaseServiceUrl) {
-            log.error("Invalid application configuration: security.shiro.cas.baseServiceUrl is required; it should be http://host:port/")
+            log.error("Invalid application configuration: security.shiro.cas.baseServiceUrl is not set, and could not be dynamically determined")
         }
 
-        if (!servicePath) {
-            log.error("Invalid application configuration: security.shiro.cas.servicePath is required; it should be /mycontextpath/shiro-cas")
-        }
-
-        return serverUrl && defaultBaseServiceUrl && servicePath
+        return serverUrl && defaultBaseServiceUrl
     }
 
     static String getServerUrl() {

--- a/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
@@ -1,6 +1,12 @@
 package org.apache.shiro.cas.grails
 
 class ConfigurationFixtures {
+    static ConfigObject getServerUrlOnlyConfiguration() {
+        return new ConfigSlurper().parse("""
+security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
+        """)
+    }
+
     static ConfigObject getMinimalConfiguration() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"

--- a/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
@@ -1,0 +1,57 @@
+package org.apache.shiro.cas.grails
+
+class ConfigurationFixtures {
+    static ConfigObject getMinimalConfiguration() {
+        return new ConfigSlurper().parse("""
+security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
+        """)
+    }
+
+    static ConfigObject getFullConfiguration() {
+        return new ConfigSlurper().parse("""
+security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.loginUrl = "https://cas.example.com/cas/customLogin"
+security.shiro.cas.logoutUrl = "https://cas.example.com/cas/customLogout"
+security.shiro.cas.failurePath = "/casFailure"
+security.shiro.filter.filterChainDefinitions = "/other=otherFilter"
+security.shiro.cas.loginParameters.renew = true
+security.shiro.cas.singleSignOut.disabled = false
+security.shiro.cas.singleSignOut.artifactParameterName = "token"
+security.shiro.cas.singleSignOut.logoutParameterName = "slo"
+        """)
+    }
+
+    static ConfigObject getConfigurationWithLoginParameters() {
+        return new ConfigSlurper().parse("""
+security.shiro.cas.serverUrl = "https://localhost/cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.loginParameters.renew = true
+security.shiro.cas.loginParameters.gateway = true
+security.shiro.cas.loginParameters.welcome = "Welcome to Shiro Cas"
+        """)
+    }
+
+    static ConfigObject getConfigurationWithSingleSignOnDisabled() {
+        return new ConfigSlurper().parse("""
+security.shiro.cas.serverUrl = "https://localhost/cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.singleSignOut.disabled = true
+        """)
+    }
+
+    static ConfigObject getConfigurationWithDynamicServerName() {
+        return new ConfigSlurper().parse("""
+security.shiro.cas.serverUrl = "https://localhost/cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/test/shiro-cas"
+security.shiro.cas.failurePath = "/test/"
+security.shiro.cas.multiDomain = true
+        """)
+    }
+}

--- a/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
@@ -4,19 +4,19 @@ class ConfigurationFixtures {
     static ConfigObject getMinimalConfiguration() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
-security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
+security.shiro.cas.servicePath = "/app/shiro-cas"
         """)
     }
 
     static ConfigObject getFullConfiguration() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
-security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
+security.shiro.cas.servicePath = "/app/shiro-cas"
 security.shiro.cas.loginUrl = "https://cas.example.com/cas/customLogin"
 security.shiro.cas.logoutUrl = "https://cas.example.com/cas/customLogout"
-security.shiro.cas.failurePath = "/casFailure"
+security.shiro.cas.failurePath = "/app/casFailure"
 security.shiro.filter.filterChainDefinitions = "/other=otherFilter"
 security.shiro.cas.loginParameters.renew = true
 security.shiro.cas.singleSignOut.disabled = false
@@ -27,9 +27,9 @@ security.shiro.cas.singleSignOut.logoutParameterName = "slo"
 
     static ConfigObject getConfigurationWithLoginParameters() {
         return new ConfigSlurper().parse("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
-security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
+security.shiro.cas.servicePath = "/app/shiro-cas"
 security.shiro.cas.loginParameters.renew = true
 security.shiro.cas.loginParameters.gateway = true
 security.shiro.cas.loginParameters.welcome = "Welcome to Shiro Cas"
@@ -38,19 +38,19 @@ security.shiro.cas.loginParameters.welcome = "Welcome to Shiro Cas"
 
     static ConfigObject getConfigurationWithSingleSignOnDisabled() {
         return new ConfigSlurper().parse("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
-security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
+security.shiro.cas.servicePath = "/app/shiro-cas"
 security.shiro.cas.singleSignOut.disabled = true
         """)
     }
 
     static ConfigObject getConfigurationWithDynamicServerName() {
         return new ConfigSlurper().parse("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
-security.shiro.cas.servicePath = "/test/shiro-cas"
-security.shiro.cas.failurePath = "/test/"
+security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
+security.shiro.cas.servicePath = "/app/shiro-cas"
+security.shiro.cas.failurePath = "/app/casFailure"
 security.shiro.cas.multiDomain = true
         """)
     }

--- a/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
@@ -51,7 +51,6 @@ security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
 security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
 security.shiro.cas.servicePath = "/app/shiro-cas"
 security.shiro.cas.failurePath = "/app/casFailure"
-security.shiro.cas.multiDomain = true
         """)
     }
 }

--- a/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
@@ -10,19 +10,19 @@ security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
     static ConfigObject getMinimalConfiguration() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
-security.shiro.cas.servicePath = "/app/shiro-cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
         """)
     }
 
     static ConfigObject getFullConfiguration() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
-security.shiro.cas.servicePath = "/app/shiro-cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
 security.shiro.cas.loginUrl = "https://cas.example.com/cas/customLogin"
 security.shiro.cas.logoutUrl = "https://cas.example.com/cas/customLogout"
-security.shiro.cas.failurePath = "/app/casFailure"
+security.shiro.cas.failurePath = "/casFailure"
 security.shiro.filter.filterChainDefinitions = "/other=otherFilter"
 security.shiro.cas.loginParameters.renew = true
 security.shiro.cas.singleSignOut.disabled = false
@@ -34,8 +34,8 @@ security.shiro.cas.singleSignOut.logoutParameterName = "slo"
     static ConfigObject getConfigurationWithLoginParameters() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
-security.shiro.cas.servicePath = "/app/shiro-cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
 security.shiro.cas.loginParameters.renew = true
 security.shiro.cas.loginParameters.gateway = true
 security.shiro.cas.loginParameters.welcome = "Welcome to Shiro Cas"
@@ -45,8 +45,8 @@ security.shiro.cas.loginParameters.welcome = "Welcome to Shiro Cas"
     static ConfigObject getConfigurationWithSingleSignOnDisabled() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
-security.shiro.cas.servicePath = "/app/shiro-cas"
+security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"
+security.shiro.cas.servicePath = "/shiro-cas"
 security.shiro.cas.singleSignOut.disabled = true
         """)
     }
@@ -54,9 +54,8 @@ security.shiro.cas.singleSignOut.disabled = true
     static ConfigObject getConfigurationWithDynamicServerName() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
-security.shiro.cas.baseServiceUrl = "https://localhost:8080/"
-security.shiro.cas.servicePath = "/app/shiro-cas"
-security.shiro.cas.failurePath = "/app/casFailure"
+security.shiro.cas.servicePath = "/shiro-cas"
+security.shiro.cas.failurePath = "/casFailure"
         """)
     }
 }

--- a/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ConfigurationFixtures.groovy
@@ -42,7 +42,7 @@ security.shiro.cas.loginParameters.welcome = "Welcome to Shiro Cas"
         """)
     }
 
-    static ConfigObject getConfigurationWithSingleSignOnDisabled() {
+    static ConfigObject getConfigurationWithSingleSignOutDisabled() {
         return new ConfigSlurper().parse("""
 security.shiro.cas.serverUrl = "https://cas.example.com/cas/"
 security.shiro.cas.baseServiceUrl = "https://localhost:8080/app/"

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -39,7 +39,6 @@ class ShiroCasConfigUtilsSpec extends Specification {
 
         then: "config errors are logged"
         1 * mockLog.error("Invalid application configuration: security.shiro.cas.serverUrl is required; it should be https://host:port/cas")
-        1 * mockLog.error("Invalid application configuration: security.shiro.cas.baseServiceUrl is not set, and could not be dynamically determined")
     }
 
     void "minimal configuration is dynamically determined when the serverUrl is set"() {

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -27,8 +27,8 @@ class ShiroCasConfigUtilsSpec extends Specification {
 
         then: "config errors are logged"
         1 * mockLog.error("Invalid application configuration: security.shiro.cas.serverUrl is required; it should be https://host:port/cas")
-        1 * mockLog.error('Invalid application configuration: security.shiro.cas.servicePath is required; it should be /shiro-cas')
-        1 * mockLog.error('Invalid application configuration: security.shiro.cas.baseServiceUrl is required; it should be http://host:port/mycontextpath/')
+        1 * mockLog.error('Invalid application configuration: security.shiro.cas.servicePath is required; it should be /mycontextpath/shiro-cas')
+        1 * mockLog.error('Invalid application configuration: security.shiro.cas.baseServiceUrl is required; it should be http://host:port/')
 
         and: "a default (but non-working) configuration is used"
         ShiroCasConfigUtils.serverUrl == ""
@@ -36,10 +36,6 @@ class ShiroCasConfigUtilsSpec extends Specification {
         ShiroCasConfigUtils.defaultLoginUrl == ""
         ShiroCasConfigUtils.defaultLogoutUrl == ""
         ShiroCasConfigUtils.failureUrl == ""
-        ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n"
-        !ShiroCasConfigUtils.singleSignOutDisabled
-        ShiroCasConfigUtils.singleSignOutArtifactParameterName == "ticket"
-        ShiroCasConfigUtils.singleSignOutLogoutParameterName == "logoutRequest"
     }
 
     void "minimal configuration works"() {

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -101,12 +101,12 @@ class ShiroCasConfigUtilsSpec extends Specification {
         0 * mockLog.error(_)
 
         and: "the configured values are used"
-        ShiroCasConfigUtils.serverUrl == "https://localhost/cas"
+        ShiroCasConfigUtils.serverUrl == "https://cas.example.com/cas"
         ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
 
         and: "other values are either defaulted or based on the configured values"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://localhost/cas/login?service=https://localhost:8080/app/shiro-cas&renew=true&gateway=true&welcome=Welcome%20to%20Shiro%20Cas"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://localhost/cas/logout?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&renew=true&gateway=true&welcome=Welcome%20to%20Shiro%20Cas"
+        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
         ShiroCasConfigUtils.failureUrl == ""
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n"
     }
@@ -146,12 +146,12 @@ class ShiroCasConfigUtilsSpec extends Specification {
 
         then: "URLs overridden using first domain"
         2 * httpServletRequest.getRequestURL() >> new StringBuffer(firstUrl)
-        firstServiceUrl == firstUrl + "/test/shiro-cas"
-        firstFailureUrl == firstUrl + "/test/"
+        firstServiceUrl == firstUrl + "/app/shiro-cas"
+        firstFailureUrl == firstUrl + "/app/casFailure"
 
         then: "URLs overridden using second domain"
         2 * httpServletRequest.getRequestURL() >> new StringBuffer(secondUrl)
-        secondServiceUrl == secondUrl + "/test/shiro-cas"
-        secondFailureUrl == secondUrl + "/test/"
+        secondServiceUrl == secondUrl + "/app/shiro-cas"
+        secondFailureUrl == secondUrl + "/app/casFailure"
     }
 }

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -23,18 +23,19 @@ class ShiroCasConfigUtilsSpec extends Specification {
 
     void "missing config logs errors"() {
         when: "initialized with no configuration"
-        init("")
+        ShiroCasConfigUtils.initialize(new ConfigObject())
 
         then: "config errors are logged"
         1 * mockLog.error("Invalid application configuration: security.shiro.cas.serverUrl is required; it should be https://host:port/cas")
-        1 * mockLog.error("Invalid application configuration: security.shiro.cas.serviceUrl is required; it should be http://host:port/mycontextpath/shiro-cas")
+        1 * mockLog.error('Invalid application configuration: security.shiro.cas.servicePath is required; it should be /shiro-cas')
+        1 * mockLog.error('Invalid application configuration: security.shiro.cas.baseServiceUrl is required; it should be http://host:port/mycontextpath/')
 
         and: "a default (but non-working) configuration is used"
         ShiroCasConfigUtils.serverUrl == ""
         ShiroCasConfigUtils.serviceUrl == ""
         ShiroCasConfigUtils.defaultLoginUrl == ""
         ShiroCasConfigUtils.defaultLogoutUrl == ""
-        ShiroCasConfigUtils.failureUrl == null
+        ShiroCasConfigUtils.failureUrl == ""
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n"
         !ShiroCasConfigUtils.singleSignOutDisabled
         ShiroCasConfigUtils.singleSignOutArtifactParameterName == "ticket"
@@ -43,22 +44,19 @@ class ShiroCasConfigUtilsSpec extends Specification {
 
     void "minimal configuration works"() {
         when: "initialized with a minimal configuration"
-        init("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
-        """)
+        ShiroCasConfigUtils.initialize(ConfigurationFixtures.minimalConfiguration)
 
         then: "no errors are logged"
         0 * mockLog.error(_)
 
         and: "the configured values are used"
-        ShiroCasConfigUtils.serverUrl == "https://localhost/cas"
-        ShiroCasConfigUtils.serviceUrl == "http://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.serverUrl == "https://cas.example.com/cas"
+        ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
 
         and: "other values are either defaulted or based on the configured values"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://localhost/cas/login?service=http://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://localhost/cas/logout?service=http://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.failureUrl == null
+        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.failureUrl == ""
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n"
         !ShiroCasConfigUtils.singleSignOutDisabled
         ShiroCasConfigUtils.singleSignOutArtifactParameterName == "ticket"
@@ -67,29 +65,17 @@ security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
 
     void "full configuration works"() {
         when: "initalized with a full config"
-        init("""
-security.shiro.cas.serverUrl = "https://cas.example.com"
-security.shiro.cas.serviceUrl = "https://app.example.com/shiro-cas"
-security.shiro.cas.loginUrl = "https://cas.example.com/customLogin"
-security.shiro.cas.logoutUrl = "https://cas.example.com/customLogout"
-security.shiro.cas.failureUrl = "https://app.example.com/casFailure"
-security.shiro.filter.filterChainDefinitions = "/other=otherFilter"
-security.shiro.cas.loginParameters.renew = true
-security.shiro.cas.singleSignOut.disabled = false
-security.shiro.cas.singleSignOut.artifactParameterName = "token"
-security.shiro.cas.singleSignOut.logoutParameterName = "slo"
-
-        """)
+        ShiroCasConfigUtils.initialize(ConfigurationFixtures.fullConfiguration)
 
         then: "no errors are logged"
         0 * mockLog.error(_)
 
         and: "the configured values are used"
-        ShiroCasConfigUtils.serverUrl == "https://cas.example.com"
-        ShiroCasConfigUtils.serviceUrl == "https://app.example.com/shiro-cas"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/customLogin?renew=true"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/customLogout"
-        ShiroCasConfigUtils.failureUrl == "https://app.example.com/casFailure"
+        ShiroCasConfigUtils.serverUrl == "https://cas.example.com/cas"
+        ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/customLogin?renew=true"
+        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/customLogout"
+        ShiroCasConfigUtils.failureUrl == "https://localhost:8080/app/casFailure"
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n/other=otherFilter"
         !ShiroCasConfigUtils.singleSignOutDisabled
         ShiroCasConfigUtils.singleSignOutArtifactParameterName == "token"
@@ -98,50 +84,38 @@ security.shiro.cas.singleSignOut.logoutParameterName = "slo"
 
     void "trailing slashes on URLs are ignored"() {
         when: "initialized with server url and/or service url containing a trailing slash"
-        init("""
-security.shiro.cas.serverUrl = "https://localhost/cas/"
-security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas/"
-        """)
+        ShiroCasConfigUtils.initialize(ConfigurationFixtures.minimalConfiguration)
 
         then: "the trailing slash is ignored"
-        ShiroCasConfigUtils.serverUrl == "https://localhost/cas"
-        ShiroCasConfigUtils.serviceUrl == "http://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://localhost/cas/login?service=http://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://localhost/cas/logout?service=http://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.serverUrl == "https://cas.example.com/cas"
+        ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
     }
 
     void "specified login parameters are honored"() {
         when: "initialized with a configuration including login parameters"
-        init("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
-security.shiro.cas.loginParameters.renew = true
-security.shiro.cas.loginParameters.gateway = true
-security.shiro.cas.loginParameters.welcome = "Welcome to Shiro Cas"
-        """)
+        ShiroCasConfigUtils.initialize(ConfigurationFixtures.configurationWithLoginParameters)
 
         then: "no errors are logged"
         0 * mockLog.error(_)
 
         and: "the configured values are used"
         ShiroCasConfigUtils.serverUrl == "https://localhost/cas"
-        ShiroCasConfigUtils.serviceUrl == "http://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
 
         and: "other values are either defaulted or based on the configured values"
-        ShiroCasConfigUtils.defaultLoginUrl ==
-                "https://localhost/cas/login?service=http://localhost:8080/app/shiro-cas&renew=true&gateway=true&welcome=Welcome%20to%20Shiro%20Cas"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://localhost/cas/logout?service=http://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.failureUrl == null
+        ShiroCasConfigUtils.defaultLoginUrl == "https://localhost/cas/login?service=https://localhost:8080/app/shiro-cas&renew=true&gateway=true&welcome=Welcome%20to%20Shiro%20Cas"
+        ShiroCasConfigUtils.defaultLogoutUrl == "https://localhost/cas/logout?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.failureUrl == ""
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n"
     }
 
     void "single sign out support can be disabled"() {
         when: "initialized with a configuration including login parameters"
-        init("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
-security.shiro.cas.singleSignOut.disabled = true
-        """)
+        def config = ConfigurationFixtures.configurationWithSingleSignOnDisabled
+        Holders.config = config
+        ShiroCasConfigUtils.initialize(config)
 
         then: "no errors are logged"
         0 * mockLog.error(_)
@@ -163,12 +137,7 @@ security.shiro.cas.singleSignOut.disabled = true
 
 
         when: "initialized with a dynamicServerName configuration"
-        init("""
-security.shiro.cas.serverUrl = "https://localhost/cas"
-security.shiro.cas.serviceUrl = "http://localhost:8080/app/shiro-cas"
-security.shiro.cas.servicePath = "/test/shiro-cas"
-security.shiro.cas.failurePath = "/test/"
-        """)
+        ShiroCasConfigUtils.initialize(ConfigurationFixtures.configurationWithDynamicServerName)
 
         def firstServiceUrl = ShiroCasConfigUtils.serviceUrl
         def firstFailureUrl = ShiroCasConfigUtils.failureUrl
@@ -184,11 +153,5 @@ security.shiro.cas.failurePath = "/test/"
         2 * httpServletRequest.getRequestURL() >> new StringBuffer(secondUrl)
         secondServiceUrl == secondUrl + "/test/shiro-cas"
         secondFailureUrl == secondUrl + "/test/"
-    }
-
-    static void init(String script) {
-        def config = new ConfigSlurper().parse(script)
-        Holders.config = config
-        ShiroCasConfigUtils.initialize(config)
     }
 }

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -130,7 +130,7 @@ class ShiroCasConfigUtilsSpec extends Specification {
 
     void "single sign out support can be disabled"() {
         when: "initialized with a configuration including login parameters"
-        def config = ConfigurationFixtures.configurationWithSingleSignOnDisabled
+        def config = ConfigurationFixtures.configurationWithSingleSignOutDisabled
         Holders.config = config
         ShiroCasConfigUtils.initialize(config)
 

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -143,7 +143,8 @@ class ShiroCasConfigUtilsSpec extends Specification {
 
     void "configurations without a baseServiceUrl use dynamic URLs from the application context"(){
         setup:
-        mockLinkGenerator.getServerBaseURL() >> "https://dynamic.test.server/ctx/"
+        2 * mockLinkGenerator.getServerBaseURL() >> "https://dynamic.test.server/ctx/"
+        2 * mockLinkGenerator.getServerBaseURL() >> "https://second.test.server/ctx/"
 
         when: "initialized with a dynamicServerName configuration"
         ShiroCasConfigUtils.initialize(ConfigurationFixtures.configurationWithDynamicServerName)
@@ -151,6 +152,9 @@ class ShiroCasConfigUtilsSpec extends Specification {
         then: "URLs overridden using first domain"
         ShiroCasConfigUtils.serviceUrl == "https://dynamic.test.server/ctx/shiro-cas"
         ShiroCasConfigUtils.failureUrl == "https://dynamic.test.server/ctx/casFailure"
-        def firstFailureUrl = ShiroCasConfigUtils.failureUrl
+
+        then: "URLs overridden using second domain"
+        ShiroCasConfigUtils.serviceUrl == "https://second.test.server/ctx/shiro-cas"
+        ShiroCasConfigUtils.failureUrl == "https://second.test.server/ctx/casFailure"
     }
 }

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -71,8 +71,8 @@ class ShiroCasConfigUtilsSpec extends Specification {
         ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
 
         and: "other values are either defaulted or based on the configured values"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.loginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.logoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
         ShiroCasConfigUtils.failureUrl == ""
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n"
         !ShiroCasConfigUtils.singleSignOutDisabled
@@ -90,8 +90,8 @@ class ShiroCasConfigUtilsSpec extends Specification {
         and: "the configured values are used"
         ShiroCasConfigUtils.serverUrl == "https://cas.example.com/cas"
         ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/customLogin?renew=true"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/customLogout"
+        ShiroCasConfigUtils.loginUrl == "https://cas.example.com/cas/customLogin?renew=true"
+        ShiroCasConfigUtils.logoutUrl == "https://cas.example.com/cas/customLogout"
         ShiroCasConfigUtils.failureUrl == "https://localhost:8080/app/casFailure"
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n/other=otherFilter"
         !ShiroCasConfigUtils.singleSignOutDisabled
@@ -106,8 +106,8 @@ class ShiroCasConfigUtilsSpec extends Specification {
         then: "the trailing slash is ignored"
         ShiroCasConfigUtils.serverUrl == "https://cas.example.com/cas"
         ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.loginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.logoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
     }
 
     void "specified login parameters are honored"() {
@@ -122,8 +122,8 @@ class ShiroCasConfigUtilsSpec extends Specification {
         ShiroCasConfigUtils.serviceUrl == "https://localhost:8080/app/shiro-cas"
 
         and: "other values are either defaulted or based on the configured values"
-        ShiroCasConfigUtils.defaultLoginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&renew=true&gateway=true&welcome=Welcome%20to%20Shiro%20Cas"
-        ShiroCasConfigUtils.defaultLogoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasConfigUtils.loginUrl == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&renew=true&gateway=true&welcome=Welcome%20to%20Shiro%20Cas"
+        ShiroCasConfigUtils.logoutUrl == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
         ShiroCasConfigUtils.failureUrl == ""
         ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n"
     }

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasUrlBuilderSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasUrlBuilderSpec.groovy
@@ -4,27 +4,23 @@ import spock.lang.Specification
 
 import javax.servlet.http.HttpServletResponse
 
-@SuppressWarnings("GrMethodMayBeStatic")
 class ShiroCasUrlBuilderSpec extends Specification {
     def setup() {
-        init("""
-security.shiro.cas.serverUrl = "https://cas.example.com"
-security.shiro.cas.serviceUrl = "https://app.example.com/shiro-cas"
-        """)
+        ShiroCasConfigUtils.initialize(ConfigurationFixtures.minimalConfiguration)
     }
 
     def "can build from login"() {
         expect:
-        ShiroCasUrlBuilder.forLogin().url == "https://cas.example.com/login?service=https://app.example.com/shiro-cas"
-        ShiroCasUrlBuilder.forLogin().withGateway().url == "https://cas.example.com/login?service=https://app.example.com/shiro-cas&gateway=true"
-        ShiroCasUrlBuilder.forLogin().withRenew().url == "https://cas.example.com/login?service=https://app.example.com/shiro-cas&renew=true"
-        ShiroCasUrlBuilder.forLogin().withQueryParam("token", "12345").url == "https://cas.example.com/login?service=https://app.example.com/shiro-cas&token=12345"
+        ShiroCasUrlBuilder.forLogin().url == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasUrlBuilder.forLogin().withGateway().url == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&gateway=true"
+        ShiroCasUrlBuilder.forLogin().withRenew().url == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&renew=true"
+        ShiroCasUrlBuilder.forLogin().withQueryParam("token", "12345").url == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&token=12345"
     }
 
     def "can build from logout"() {
         expect:
-        ShiroCasUrlBuilder.forLogout().url == "https://cas.example.com/logout?service=https://app.example.com/shiro-cas"
-        ShiroCasUrlBuilder.forLogout().withQueryParam("token", "12345").url == "https://cas.example.com/logout?service=https://app.example.com/shiro-cas&token=12345"
+        ShiroCasUrlBuilder.forLogout().url == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas"
+        ShiroCasUrlBuilder.forLogout().withQueryParam("token", "12345").url == "https://cas.example.com/cas/logout?service=https://localhost:8080/app/shiro-cas&token=12345"
     }
 
     def "can redirect"() {
@@ -34,22 +30,17 @@ security.shiro.cas.serviceUrl = "https://app.example.com/shiro-cas"
         ShiroCasUrlBuilder.forLogin().go(response)
 
         then:
-        1 * response.sendRedirect("https://cas.example.com/login?service=https://app.example.com/shiro-cas")
+        1 * response.sendRedirect("https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas")
 
         when:
         ShiroCasUrlBuilder.forLogin().withRenew().withQueryParam("token", "12345").go(response)
 
         then:
-        1 * response.sendRedirect("https://cas.example.com/login?service=https://app.example.com/shiro-cas&renew=true&token=12345")
+        1 * response.sendRedirect("https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&renew=true&token=12345")
     }
 
     def "query parameters are encoded"() {
         expect:
-        ShiroCasUrlBuilder.forLogin().withQueryParam("message", "Welcome to CAS").url == "https://cas.example.com/login?service=https://app.example.com/shiro-cas&message=Welcome%20to%20CAS"
-    }
-
-    static void init(String script) {
-        def config = new ConfigSlurper().parse(script)
-        ShiroCasConfigUtils.initialize(config)
+        ShiroCasUrlBuilder.forLogin().withQueryParam("message", "Welcome to CAS").url == "https://cas.example.com/cas/login?service=https://localhost:8080/app/shiro-cas&message=Welcome%20to%20CAS"
     }
 }


### PR DESCRIPTION
This PR unifies the way in which this plugin is configured for single-domain and multi-domain scenarios. Instead of using one URL in one case, or a base URL + path in the other, the plugin is always configured with a base URL and path, and will optionally try to determine the path dynamically if multi-domain support is turned on.

A single-domain configuration would look like this:

```groovy
security.shiro.cas.serverUrl='https://sso.example.com/cas'
security.shiro.cas.baseServiceUrl='https://apps.example.com/my-app/'
security.shiro.cas.servicePath='/shiro-cas'
```

Switching to a multi-domain scenario only requires the addition of one more config line:

```groovy
security.shiro.cas.serverUrl='https://sso.example.com/cas'
security.shiro.cas.baseServiceUrl='https://apps.example.com/my-app/'
security.shiro.cas.servicePath='/shiro-cas'
security.shiro.cas.multiDomain=true
```

This makes the code easier to follow, reduces code repetition, and will make a set of modifications I'm working on much simpler.

I also cleaned up the tests, extracting sample configurations to a fixture class, and making the example URLs consistent.