### PR TITLE
Using configured servicePath instead of hardcoded default

### DIFF
--- a/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
+++ b/src/groovy/org/apache/shiro/cas/grails/ShiroCasConfigUtils.groovy
@@ -138,12 +138,14 @@ class ShiroCasConfigUtils {
 
     static String getShiroCasFilter() {
         def filters = new StringBuilder()
+        filters.append(servicePath)
+
         if (!isSingleSignOutDisabled()) {
             // The SingleSignOutFilter must come before the CAS filter
             // https://wiki.jasig.org/display/CASC/Configuring+Single+Sign+Out
-            filters.append("/shiro-cas=singleSignOutFilter,casFilter\n")
+            filters.append("=singleSignOutFilter,casFilter\n")
         } else {
-            filters.append("/shiro-cas=casFilter\n")
+            filters.append("=casFilter\n")
         }
         filters.append(filterChainDefinitions)
         return filters.toString()

--- a/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
+++ b/test/unit/org/apache/shiro/cas/grails/ShiroCasConfigUtilsSpec.groovy
@@ -113,7 +113,7 @@ class ShiroCasConfigUtilsSpec extends Specification {
         ShiroCasConfigUtils.loginUrl == "https://cas.example.com/cas/custom-login?renew=true"
         ShiroCasConfigUtils.logoutUrl == "https://cas.example.com/cas/custom-logout"
         ShiroCasConfigUtils.failureUrl == "https://localhost:8080/app/cas-failure"
-        ShiroCasConfigUtils.shiroCasFilter == "/shiro-cas=singleSignOutFilter,casFilter\n/other=otherFilter"
+        ShiroCasConfigUtils.shiroCasFilter == "/cas-callback=singleSignOutFilter,casFilter\n/other=otherFilter"
         !ShiroCasConfigUtils.singleSignOutDisabled
         ShiroCasConfigUtils.singleSignOutArtifactParameterName == "token"
         ShiroCasConfigUtils.singleSignOutLogoutParameterName == "slo"


### PR DESCRIPTION
This PR fixes a bug by updating the filter chain definitions to use the `servicePath` rather than a hardcoded `/shiro-cas` path. Previously it was not possible to get SLO (Single Log Out) working without manually adding filters to `web.xml` if you were using a non-default CAS service endpoint in your Grails app.